### PR TITLE
Chore (Install Minimal Dependencies)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,5 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.6",
+    install_requires=['requests']
 )


### PR DESCRIPTION
### What does this PR do?

Install the minimal dependency, **requests**, that is required for the package to run
correctly.

### Any background tasks?

It was noted that the application failed to run correctly due to its dependency on the python **requests** library which should be installed first before using the package.
The **requests dependency** will be installed during the installation process of the package, therefore, preventing the application from breaking.

### Branch Name

ch-install-minimal-dependencies