### PR TITLE
added support for python < 3.9

### DIFF
--- a/src/autodesk_forge_sdk/__init__.py
+++ b/src/autodesk_forge_sdk/__init__.py
@@ -4,5 +4,5 @@ Clients for communicating with different Autodesk Forge services.
 
 from .auth import AuthenticationClient, Scope, get_authorization_url
 from .auth import TokenProviderInterface, SimpleTokenProvider, OAuthTokenProvider
-from .dm import OSSClient, DataManagementClient
+from .dm import OSSClient, DataManagementClient, DocumentManagementClient
 from .md import ModelDerivativeClient, urnify

--- a/src/autodesk_forge_sdk/auth.py
+++ b/src/autodesk_forge_sdk/auth.py
@@ -4,6 +4,7 @@ Clients for working with the Forge Authentication service.
 
 from enum import Enum
 from datetime import datetime, timedelta
+from typing import List
 from urllib.parse import quote
 from .base import BaseClient
 
@@ -87,7 +88,7 @@ class Scope(Enum):
 
 def get_authorization_url(
         client_id: str, response_type: str, redirect_uri: str,
-        scopes: list[Scope], state: str = None
+        scopes: List[Scope], state: str = None
     ) -> str:
     """
     Generate a URL to redirect an end user to in order to acquire the user’s consent
@@ -101,7 +102,7 @@ def get_authorization_url(
             for implicit grant flow.
         redirect_uri (str): URL-encoded callback URL that the end user will be redirected to
             after completing the authorization flow.
-        scopes (list[Scope]): List of required scopes.
+        scopes (List[Scope]): List of required scopes.
         state (str, optional): Payload containing arbitrary data that the authentication flow
             will pass back verbatim in a state query parameter to the callback URL.
 
@@ -144,7 +145,7 @@ class AuthenticationClient(BaseClient):
         """
         BaseClient.__init__(self, base_url)
 
-    def authenticate(self, client_id: str, client_secret: str, scopes: list[Scope]) -> dict:
+    def authenticate(self, client_id: str, client_secret: str, scopes: List[Scope]) -> dict:
         """
         Generate a two-legged access token for specific set of scopes.
 
@@ -154,7 +155,7 @@ class AuthenticationClient(BaseClient):
         Args:
             client_id (str): Client ID of the app.
             client_secret (str): Client secret of the app.
-            scopes (list[Scope]): List of required scopes.
+            scopes (List[Scope]): List of required scopes.
 
         Returns:
             dict: Parsed response object with properties `access_token`, `token_type`,
@@ -221,7 +222,7 @@ class AuthenticationClient(BaseClient):
         return self._post('/gettoken', form=form).json()
 
     def refresh_token(
-        self, client_id: str, client_secret: str, refresh_token: str, scopes: list[Scope]) -> dict:
+        self, client_id: str, client_secret: str, refresh_token: str, scopes: List[Scope]) -> dict:
         """
         Acquire a new access token by using the refresh token provided by `get_token`.
 
@@ -232,7 +233,7 @@ class AuthenticationClient(BaseClient):
             client_id (str): Client ID of the app.
             client_secret (str): Client secret of the app.
             refresh_token (str): Refresh token used to acquire a new access token.
-            scopes (list[str]): List of required scopes.
+            scopes (List[str]): List of required scopes.
 
         Returns:
             dict: Parsed response object with properties `token_type`, `access_token`,
@@ -288,12 +289,12 @@ class TokenProviderInterface:
     Interface for any class that can provide access tokens to API clients
     based on a set of OAuth scopes.
     """
-    def get_token(self, scopes: list[Scope]) -> str:
+    def get_token(self, scopes: List[Scope]) -> str:
         """
         Generates access token for given set of scopes.
 
         Args:
-            scopes (list[Scope]): List of scopes that the generated access token should support.
+            scopes (List[Scope]): List of scopes that the generated access token should support.
 
         Returns:
             str: Access token.
@@ -318,7 +319,7 @@ class SimpleTokenProvider(TokenProviderInterface):
         """
         self.access_token = access_token
 
-    def get_token(self, scopes: list[Scope]) -> str:
+    def get_token(self, scopes: List[Scope]) -> str:
         return self.access_token
 
 
@@ -341,7 +342,7 @@ class OAuthTokenProvider(TokenProviderInterface):
         self.auth_client = AuthenticationClient()
         self.cache = {}
 
-    def get_token(self, scopes: list[Scope]) -> str:
+    def get_token(self, scopes: List[Scope]) -> str:
         cache_key = "+".join(map(lambda s: s.value, scopes))
         now = datetime.now()
         if cache_key in self.cache:
@@ -410,7 +411,7 @@ class BaseOAuthClient(BaseClient):
             del kwargs["scopes"]
         return BaseClient._delete(self, url, **kwargs)
 
-    def _set_auth_headers(self, headers: dict, scopes: list[Scope]):
+    def _set_auth_headers(self, headers: dict, scopes: List[Scope]):
         if "Authorization" not in headers:
             auth = self.token_provider.get_token(scopes)
             headers["Authorization"] = "Bearer {}".format(auth["access_token"])

--- a/src/autodesk_forge_sdk/dm.py
+++ b/src/autodesk_forge_sdk/dm.py
@@ -4,7 +4,6 @@ Clients for working with the Forge Data Management service.
 from os import path
 from enum import Enum
 from typing import Union
-from urllib.parse import quote
 from .auth import BaseOAuthClient, Scope, TokenProviderInterface
 
 BASE_URL = "https://developer.api.autodesk.com"
@@ -12,7 +11,6 @@ OSS_BASE_URL = f"{BASE_URL}/oss/v2"
 DATA_MANAGEMENT_DATA_URL = f"{BASE_URL}/data/v1"
 DATA_MANAGEMENT_PROJECT_URL = f"{BASE_URL}/project/v1"
 DOCUMENT_MANAGEMENT_URL = f"{BASE_URL}/bim360/docs/v1"
-#DATA_MANAGEMENT_BASE_URL = "https://developer.api.autodesk.com/project/v1"
 READ_SCOPES = [Scope.BUCKET_READ, Scope.DATA_READ]
 WRITE_SCOPES = [Scope.BUCKET_CREATE, Scope.DATA_CREATE, Scope.DATA_WRITE]
 DELETE_SCOPES = [Scope.BUCKET_DELETE]
@@ -181,7 +179,7 @@ class OSSClient(BaseOAuthClient):
             print(details)
             ```
         """
-        endpoint = "/buckets/{}/details".format(quote(bucket_key))
+        endpoint = f"/buckets/{bucket_key}/details"
         return self._get(endpoint, scopes=READ_SCOPES).json()
 
     def create_bucket(
@@ -234,7 +232,7 @@ class OSSClient(BaseOAuthClient):
         Args:
             bucket_key (str): Name of the bucket to be deleted.
         """
-        endpoint = "/buckets/{}".format(quote(bucket_key))
+        endpoint = f"/buckets/{bucket_key}"
         self._delete(endpoint, scopes=DELETE_SCOPES)
 
     def get_objects(self, bucket_key: str, **kwargs) -> dict:
@@ -273,7 +271,7 @@ class OSSClient(BaseOAuthClient):
             params["beginsWith"] = kwargs["begins_with"]
         if "start_at" in kwargs:
             params["startAt"] = kwargs["start_at"]
-        endpoint = "/buckets/{}/objects".format(quote(bucket_key))
+        endpoint = f"/buckets/{bucket_key}"
         return self._get(endpoint, scopes=READ_SCOPES, params=params).json()
 
     def get_all_objects(self, bucket_key: str, begins_with: str = None) -> list:
@@ -301,7 +299,7 @@ class OSSClient(BaseOAuthClient):
         params = {}
         if begins_with:
             params["beginsWith"] = begins_with
-        endpoint = "/buckets/{}/objects".format(quote(bucket_key))
+        endpoint = f"/buckets/{bucket_key}"
         return self._get_paginated(endpoint, scopes=READ_SCOPES, params=params)
 
     def get_object_details(self, bucket_key: str, object_key: str) -> dict:
@@ -328,7 +326,7 @@ class OSSClient(BaseOAuthClient):
             print(details)
             ```
         """
-        endpoint = "/buckets/{}/objects/{}".format(quote(bucket_key), quote(object_key))
+        endpoint = f"/buckets/{bucket_key}/objects/{object_key}"
         return self._get(endpoint, scopes=READ_SCOPES).json()
 
     def upload_object(self, bucket_key: str, object_key: str, buff) -> list:
@@ -362,7 +360,7 @@ class OSSClient(BaseOAuthClient):
                 print(obj2)
             ```
         """
-        endpoint = "/buckets/{}/objects/{}".format(quote(bucket_key), quote(object_key))
+        endpoint = f"/buckets/{bucket_key}/objects/{object_key}"
         return self._put(endpoint, buff=buff, scopes=WRITE_SCOPES).json()
 
     def delete_object(self, bucket_key: str, object_key: str):
@@ -376,13 +374,14 @@ class OSSClient(BaseOAuthClient):
             bucket_key (str): Bucket key.
             object_key (str): Name of the object to be removed.
         """
-        endpoint = "/buckets/{}/objects/{}".format(quote(bucket_key), quote(object_key))
+        endpoint = f"/buckets/{bucket_key}/objects/{object_key}"
         self._delete(endpoint, scopes=DELETE_SCOPES)
     
     def get_signeds3upload(self, bucket_key: str, object_key: str):
 
         '''
-        Requests an S3 signed URL with which to upload an object, or an array of signed URLs with which to upload an object in multiple parts.
+        Requests an S3 signed URL with which to upload an object, or an array of signed URLs with
+        which to upload an object in multiple parts.
 
         **Documentation**:
         https://forge.autodesk.com/en/docs/data/v2/reference/http/buckets-:bucketKey-objects-:objectKey-signeds3upload-GET/
@@ -399,23 +398,22 @@ class OSSClient(BaseOAuthClient):
     def post_signeds3upload(self, bucket_key: str, object_key: str, upload_key: str):
 
         '''
-        Instructs OSS to complete the object creation process after the bytes have been uploaded directly to S3.
+        Instructs OSS to complete the object creation process after the bytes have been uploaded
+        directly to S3.
         **Documentation**:
         https://forge.autodesk.com/en/docs/data/v2/reference/http/buckets-:bucketKey-objects-:objectKey-signeds3upload-POST/
 
         Args:
             bucket_key (str): Bucket key.
             object_key (str): Name of the object to be removed.
-            upload_key (str): The identifier of the upload session, which was provided by OSS in the response to the Get Upload URL/s request..
+            upload_key (str): The identifier of the upload session, which was provided by OSS in the
+            response to the Get Upload URL/s request..
 
         '''
 
         body = {"uploadKey":upload_key}
 
-        # url = f' https://developer.api.autodesk.com/oss/v2/buckets/{bucket_key}/objects/{object_key}/signeds3upload'
-        # headers = {'Authorization': f'Bearer {token}'}
         endpoint = f"/buckets/{bucket_key}/objects/{object_key}/signeds3upload"
-        
         return self._post(endpoint, json=body, scopes=WRITE_SCOPES).json()
 
 
@@ -466,15 +464,13 @@ class DocumentManagementClient(BaseOAuthClient):
     
     def get_naming_standard(self, project_id: str, naming_standard_ids: Union[list, dict]) -> dict:
         """
-        retrieving naming standard from namingStandardId.
+        Retrieves the file naming standard for a project..
 
         **Documentation**: https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-naming-standards-id-GET/
 
         Args:
             project_id (str, required): project ID
             naming_standard_id (str, required): naming standard ID.
-            filter_id (str, optional): ID to filter the results by.
-            filter_name (str, optional): Name to filter the results by.
 
         Returns:
             list(dict): List of hubs parsed from the response JSON.
@@ -492,37 +488,34 @@ class DocumentManagementClient(BaseOAuthClient):
 
             naming_standard_ids: list = naming_standard_ids['attributes']['extension']['data']['namingStandardIds']
 
-
         # check if more than one naming standard is applied to folder.
-
-        assert len(naming_standard_ids) > 0, f'No namingStandard in list "{naming_standard_ids}"'
+        assert len(naming_standard_ids) > 0, f"No namingStandard in list '{naming_standard_ids}'"
 
         assert len(naming_standard_ids) <= 1, (
             'Assuming only one "file naming standard" '
             'per folder. Has ACC changed to support more than one? see: '
             'https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-naming-standards-id-GET/. '
-            f'INFO: {len(naming_standard_ids)} namings standard ids returned '
+            f"INFO: {len(naming_standard_ids)} namings standard ids returned "
             )
 
 
         headers = { "Content-Type": "application/vnd.api+json" }
 
-        return self._get(f"/projects/{project_id}/naming-standards/{naming_standard_ids[0]}", scopes=READ_SCOPES, headers=headers).json()
+        return self._get(f"/projects/{project_id}/naming-standards/{naming_standard_ids[0]}",
+            scopes=READ_SCOPES, headers=headers).json()
     
-    def get_custom_attribute_definitions(self, project_id, folder_id, filter_id: str=None, filter_name: str=None) -> dict:
+    def get_custom_attribute_definitions(self, project_id, folder_id) -> dict:
         """
         Retrieves a complete list of custom attribute definitions for all the documents
         in a specific folder, including custom attributes that have not been assigned a
         value, as well as the potential drop-down (array) values.
 
         **Documentation**:
-        https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-naming-standards-id-GET/
+        https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-custom-attribute-definitions-GET/
 
         Args:
             project_id (str, required): project ID
             folder_id (str, required): Folder ID where where namingstandard applies.
-            filter_id (str, optional): ID to filter the results by.
-            filter_name (str, optional): Name to filter the results by.
 
         Returns:
             dict: dictoionary of naming standard from the JSON response.
@@ -531,12 +524,9 @@ class DocumentManagementClient(BaseOAuthClient):
         
         """
         headers = { "Content-Type": "application/vnd.api+json" }
-        params = {}
-        if filter_id:
-            params["filter[id]"] = filter_id
-        if filter_name:
-            params["filter[name]"] = filter_name
-        return self._get(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/folders/{folder_id}/custom-attribute-definitions", scopes=READ_SCOPES, headers=headers, params=params).json()
+
+        return self._get(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/folders/{folder_id}/custom-attribute-definitions",
+        scopes=READ_SCOPES, headers=headers).json()
 
 
 class DataManagementClient(BaseOAuthClient):
@@ -730,7 +720,8 @@ class DataManagementClient(BaseOAuthClient):
 
     def get_folder(self, project_id: str, folder_id: str, filter_id: str=None) -> dict:
         """
-        Returns the folder by ID for any folder within a given project. All folders or sub-folders within a project are associated with their own unique ID, including the root folder.
+        Returns the folder by ID for any folder within a given project. All folders or sub-folders
+        within a project are associated with their own unique ID, including the root folder.
 
         **Documentation**:
             https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-folders-folder_id-GET
@@ -759,7 +750,8 @@ class DataManagementClient(BaseOAuthClient):
     def get_content(self, project_id: str, folder_id: str, filter_id: str=None) -> dict:
         """
 
-        Returns a collection of items and folders within a folder. Items represent word documents, fusion design files, drawings, spreadsheets, etc.
+        Returns a collection of items and folders within a folder. Items represent word documents,
+        fusion design files, drawings, spreadsheets, etc.
         
         **Documentation**:
             https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-folders-folder_id-contents-GET/
@@ -787,9 +779,10 @@ class DataManagementClient(BaseOAuthClient):
         endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/folders/{folder_id}/contents"
         return self._get_paginated(endpoint, scopes=READ_SCOPES, headers=headers, params=params)
 
-    def get_item(self, project_id: str, item_id: str, filter_id: str=None) -> dict:
+    def get_item(self, project_id: str, item_id: str) -> dict:
         """
-        Retrieves metadata for a specified item. Items represent word documents, fusion design files, drawings, spreadsheets, etc.
+        Retrieves metadata for a specified item. Items represent word documents, fusion design
+        files, drawings, spreadsheets, etc.
 
         **Documentation**:
             https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-items-item_id-GET/
@@ -810,15 +803,14 @@ class DataManagementClient(BaseOAuthClient):
             ```
         """
         headers = { "Content-Type": "application/vnd.api+json" }
-        params = {}
-        if filter_id:
-            params["filter[id]"] = filter_id
+
         endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/items/{item_id}"
-        return self._get(endpoint, scopes=READ_SCOPES, headers=headers, params=params).json()
+        return self._get(endpoint, scopes=READ_SCOPES, headers=headers).json()
     
     def download_item(self, item: dict, location: str = '') -> dict:
         """
-        Retrieves metadata for a specified item. Items represent word documents, fusion design files, drawings, spreadsheets, etc.
+        Retrieves metadata for a specified item. Items represent word documents, fusion design
+        files, drawings, spreadsheets, etc.
 
         **Documentation**:
             https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-items-item_id-GET/
@@ -839,13 +831,13 @@ class DataManagementClient(BaseOAuthClient):
         except Exception as exception:
             print('item has no storage link "included.relationships.storage.meta.link.href".', {exception})
 
-        assert len(item['included']) <= 1, 'More than one "included" object. This is not supported by forge-sdk-python.'
+        assert len(item['included']) <= 1, \
+            'More than one "included" object. This is not supportedby forge-sdk-python.'
 
         filename = item['data']['attributes']['displayName']
 
         headers = { "Content-Type": "application/vnd.api+json" }
 
-        #endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/items/{item_id}"
         res = self._get(download_link, scopes=READ_SCOPES, headers=headers)
 
         with open(path.join(location, filename), 'wb') as file:
@@ -867,12 +859,6 @@ class DataManagementClient(BaseOAuthClient):
         Returns:
             dict: Dict of folders parsed from the response JSON.
         '''
-        # The POST projects/:project_id/storage endpoint creates a storage location in the OSS.
-        # the object is like urn:adsk.objects:os.object:wip.dm.emea.2/47072f30-f04e-4a9f-939f-64114e16c050.docx
-        #logger.info(f'create_storage project_id: {project_id}, filename:{filename}, folder_id: {folder_id}')
-        #url = f'https://developer.api.autodesk.com/data/v1/projects/b.{project_id}/storage'
-        
-        #headers = {'Authorization': f'Bearer {token} ', 'Content-Type': 'application/json'} # Content-Type: application/vnd.api+json
 
         body = { "jsonapi": { "version": "1.0" }, "data": {  "type": "objects",
                         "attributes": {
@@ -894,7 +880,7 @@ class DataManagementClient(BaseOAuthClient):
         return self._post(endpoint, scopes=WRITE_SCOPES, headers=headers, json=body).json()
 
 
-    def new_file_version(self, project_id, filename, item_id, object_id, type):
+    def new_file_version(self, project_id, filename, item_id, object_id, resource_type):
 
         '''
         Creates new versions of a file (item), except for the first version of the item.
@@ -917,7 +903,7 @@ class DataManagementClient(BaseOAuthClient):
                 "type": "versions",
                 "attributes": {
                     "name": filename,
-                    "extension": {"type": type, "version": "1.0"}
+                    "extension": {"type": resource_type, "version": "1.0"}
                 },
                 "relationships": {
                     "item": {"data": {"type": "items", "id": item_id}},
@@ -930,5 +916,5 @@ class DataManagementClient(BaseOAuthClient):
 
         headers = { "Content-Type": "application/vnd.api+json" }
         
-        endpoint = f' {DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/versions'
+        endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/versions"
         return self._post(endpoint, scopes=WRITE_SCOPES, headers=headers, json=body).json()

--- a/src/autodesk_forge_sdk/dm.py
+++ b/src/autodesk_forge_sdk/dm.py
@@ -1,13 +1,18 @@
 """
 Clients for working with the Forge Data Management service.
 """
-
+from os import path
 from enum import Enum
+from typing import Union
 from urllib.parse import quote
 from .auth import BaseOAuthClient, Scope, TokenProviderInterface
 
-OSS_BASE_URL = "https://developer.api.autodesk.com/oss/v2"
-DATA_MANAGEMENT_BASE_URL = "https://developer.api.autodesk.com/project/v1"
+BASE_URL = "https://developer.api.autodesk.com"
+OSS_BASE_URL = f"{BASE_URL}/oss/v2"
+DATA_MANAGEMENT_DATA_URL = f"{BASE_URL}/data/v1"
+DATA_MANAGEMENT_PROJECT_URL = f"{BASE_URL}/project/v1"
+DOCUMENT_MANAGEMENT_URL = f"{BASE_URL}/bim360/docs/v1"
+#DATA_MANAGEMENT_BASE_URL = "https://developer.api.autodesk.com/project/v1"
 READ_SCOPES = [Scope.BUCKET_READ, Scope.DATA_READ]
 WRITE_SCOPES = [Scope.BUCKET_CREATE, Scope.DATA_CREATE, Scope.DATA_WRITE]
 DELETE_SCOPES = [Scope.BUCKET_DELETE]
@@ -373,17 +378,56 @@ class OSSClient(BaseOAuthClient):
         """
         endpoint = "/buckets/{}/objects/{}".format(quote(bucket_key), quote(object_key))
         self._delete(endpoint, scopes=DELETE_SCOPES)
+    
+    def get_signeds3upload(self, bucket_key: str, object_key: str):
+
+        '''
+        Requests an S3 signed URL with which to upload an object, or an array of signed URLs with which to upload an object in multiple parts.
+
+        **Documentation**:
+        https://forge.autodesk.com/en/docs/data/v2/reference/http/buckets-:bucketKey-objects-:objectKey-signeds3upload-GET/
+
+        Args:
+            bucket_key (str): Bucket key.
+            object_key (str): Object key to create signed URL for.
+
+        '''
+        endpoint = f"/buckets/{bucket_key}/objects/{object_key}/signeds3upload"
+        
+        return self._get(endpoint, scopes=WRITE_SCOPES).json()
+    
+    def post_signeds3upload(self, bucket_key: str, object_key: str, upload_key: str):
+
+        '''
+        Instructs OSS to complete the object creation process after the bytes have been uploaded directly to S3.
+        **Documentation**:
+        https://forge.autodesk.com/en/docs/data/v2/reference/http/buckets-:bucketKey-objects-:objectKey-signeds3upload-POST/
+
+        Args:
+            bucket_key (str): Bucket key.
+            object_key (str): Name of the object to be removed.
+            upload_key (str): The identifier of the upload session, which was provided by OSS in the response to the Get Upload URL/s request..
+
+        '''
+
+        body = {"uploadKey":upload_key}
+
+        # url = f' https://developer.api.autodesk.com/oss/v2/buckets/{bucket_key}/objects/{object_key}/signeds3upload'
+        # headers = {'Authorization': f'Bearer {token}'}
+        endpoint = f"/buckets/{bucket_key}/objects/{object_key}/signeds3upload"
+        
+        return self._post(endpoint, json=body, scopes=WRITE_SCOPES).json()
 
 
-class DataManagementClient(BaseOAuthClient):
+class DocumentManagementClient(BaseOAuthClient):
     """
-    Forge Data Management data management client.
+    Forge Document Management client.
 
     **Documentation**: https://forge.autodesk.com/en/docs/data/v2/reference/http
     """
 
     def __init__(
-        self, token_provider: TokenProviderInterface, base_url: str=DATA_MANAGEMENT_BASE_URL):
+        self, token_provider: TokenProviderInterface):
         """
         Create new instance of the client.
 
@@ -406,7 +450,127 @@ class DataManagementClient(BaseOAuthClient):
             client = DataManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
             ```
         """
-        BaseOAuthClient.__init__(self, token_provider, base_url)
+        BaseOAuthClient.__init__(self, token_provider, DOCUMENT_MANAGEMENT_URL)
+
+    def _get_paginated(self, url: str, **kwargs) -> list:
+        items = []
+        while url:
+            json = self._get(url, **kwargs).json()
+            items = items + json["items"]
+            if "next" in json:
+                url = json["next"]
+            else:
+                url = None
+        return items
+
+    
+    def get_naming_standard(self, project_id: str, naming_standard_ids: Union[list, dict]) -> dict:
+        """
+        retrieving naming standard from namingStandardId.
+
+        **Documentation**: https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-naming-standards-id-GET/
+
+        Args:
+            project_id (str, required): project ID
+            naming_standard_id (str, required): naming standard ID.
+            filter_id (str, optional): ID to filter the results by.
+            filter_name (str, optional): Name to filter the results by.
+
+        Returns:
+            list(dict): List of hubs parsed from the response JSON.
+
+        Examples:
+            ```
+            THREE_LEGGED_TOKEN = os.environ["THREE_LEGGED_TOKEN"]
+            client = DocumentManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
+            naming_standard = client.get_naming_standard(project_id, naming_standard_id)
+            print(naming_standard)
+            ```
+        """
+
+        if isinstance(naming_standard_ids, dict):
+
+            naming_standard_ids: list = naming_standard_ids['attributes']['extension']['data']['namingStandardIds']
+
+
+        # check if more than one naming standard is applied to folder.
+
+        assert len(naming_standard_ids) > 0, f'No namingStandard in list "{naming_standard_ids}"'
+
+        assert len(naming_standard_ids) <= 1, (
+            'Assuming only one "file naming standard" '
+            'per folder. Has ACC changed to support more than one? see: '
+            'https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-naming-standards-id-GET/. '
+            f'INFO: {len(naming_standard_ids)} namings standard ids returned '
+            )
+
+
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        return self._get(f"/projects/{project_id}/naming-standards/{naming_standard_ids[0]}", scopes=READ_SCOPES, headers=headers).json()
+    
+    def get_custom_attribute_definitions(self, project_id, folder_id, filter_id: str=None, filter_name: str=None) -> dict:
+        """
+        Retrieves a complete list of custom attribute definitions for all the documents
+        in a specific folder, including custom attributes that have not been assigned a
+        value, as well as the potential drop-down (array) values.
+
+        **Documentation**:
+        https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-naming-standards-id-GET/
+
+        Args:
+            project_id (str, required): project ID
+            folder_id (str, required): Folder ID where where namingstandard applies.
+            filter_id (str, optional): ID to filter the results by.
+            filter_name (str, optional): Name to filter the results by.
+
+        Returns:
+            dict: dictoionary of naming standard from the JSON response.
+
+
+        
+        """
+        headers = { "Content-Type": "application/vnd.api+json" }
+        params = {}
+        if filter_id:
+            params["filter[id]"] = filter_id
+        if filter_name:
+            params["filter[name]"] = filter_name
+        return self._get(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/folders/{folder_id}/custom-attribute-definitions", scopes=READ_SCOPES, headers=headers, params=params).json()
+
+
+class DataManagementClient(BaseOAuthClient):
+    """
+    Forge Data Management data management client.
+
+    **Documentation**: https://forge.autodesk.com/en/docs/data/v2/reference/http
+    """
+
+    def __init__(
+        self, token_provider: TokenProviderInterface):
+        """
+        Create new instance of the client.
+
+        Args:
+            token_provider (autodesk_forge_sdk.auth.TokenProviderInterface):
+                Provider that will be used to generate access tokens for API calls.
+
+                Use `autodesk_forge_sdk.auth.OAuthTokenProvider` if you have your app's client ID
+                and client secret available, `autodesk_forge_sdk.auth.SimpleTokenProvider`
+                if you would like to use an existing access token instead, or even your own
+                implementation of the `autodesk_forge_sdk.auth.TokenProviderInterface` interface.
+
+                Note that many APIs in the Forge Data Management service require
+                a three-legged OAuth token.
+            base_url (str, optional): Base URL for API calls.
+
+        Examples:
+            ```
+            THREE_LEGGED_TOKEN = os.environ["THREE_LEGGED_TOKEN"]
+            client = DataManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
+            ```
+        """
+        BaseOAuthClient.__init__(self, token_provider, BASE_URL)
 
     def _get_paginated(self, url: str, **kwargs) -> list:
         json = self._get(url, **kwargs).json()
@@ -454,7 +618,7 @@ class DataManagementClient(BaseOAuthClient):
             params["filter[id]"] = filter_id
         if filter_name:
             params["filter[name]"] = filter_name
-        return self._get("/hubs", scopes=READ_SCOPES, headers=headers, params=params).json()
+        return self._get(f"{DATA_MANAGEMENT_PROJECT_URL}/hubs", scopes=READ_SCOPES, headers=headers, params=params).json()
 
     def get_all_hubs(self, filter_id: str=None, filter_name: str=None) -> dict:
         """
@@ -483,7 +647,7 @@ class DataManagementClient(BaseOAuthClient):
             params["filter[id]"] = filter_id
         if filter_name:
             params["filter[name]"] = filter_name
-        return self._get_paginated("/hubs", scopes=READ_SCOPES, headers=headers, params=params)
+        return self._get_paginated(f"{DATA_MANAGEMENT_PROJECT_URL}/hubs", scopes=READ_SCOPES, headers=headers, params=params)
 
     def get_projects(
         self, hub_id: str, filter_id: str=None, page_number: int=None, page_limit=None) -> dict:
@@ -533,7 +697,7 @@ class DataManagementClient(BaseOAuthClient):
             params["page[number]"] = page_number
         if page_limit:
             params["page[limit]"] = page_limit
-        endpoint = "/hubs/{}/projects".format(hub_id)
+        endpoint = f"{DATA_MANAGEMENT_PROJECT_URL}/hubs/{hub_id}/projects"
         return self._get(endpoint, scopes=READ_SCOPES, headers=headers, params=params).json()
 
     def get_all_projects(self, hub_id: str, filter_id: str=None) -> dict:
@@ -561,5 +725,210 @@ class DataManagementClient(BaseOAuthClient):
         params = {}
         if filter_id:
             params["filter[id]"] = filter_id
-        endpoint = "/hubs/{}/projects".format(hub_id)
+        endpoint = f"{DATA_MANAGEMENT_PROJECT_URL}/hubs/{hub_id}/projects"
         return self._get_paginated(endpoint, scopes=READ_SCOPES, headers=headers, params=params)
+
+    def get_folder(self, project_id: str, folder_id: str, filter_id: str=None) -> dict:
+        """
+        Returns the folder by ID for any folder within a given project. All folders or sub-folders within a project are associated with their own unique ID, including the root folder.
+
+        **Documentation**:
+            https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-folders-folder_id-GET
+
+        Args:
+            project_id (str): ID of a project to list folders for.
+
+        Returns:
+            list(dict): List of folders parsed from the response JSON.
+
+        Examples:
+            ```
+            THREE_LEGGED_TOKEN = os.environ["THREE_LEGGED_TOKEN"]
+            client = DataManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
+            folders = client.get_folders("some-project-id")
+            print(folders)
+            ```
+        """
+        headers = { "Content-Type": "application/vnd.api+json" }
+        params = {}
+        if filter_id:
+            params["filter[id]"] = filter_id
+        endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/folders/{folder_id}"
+        return self._get_paginated(endpoint, scopes=READ_SCOPES, headers=headers, params=params)
+
+    def get_content(self, project_id: str, folder_id: str, filter_id: str=None) -> dict:
+        """
+
+        Returns a collection of items and folders within a folder. Items represent word documents, fusion design files, drawings, spreadsheets, etc.
+        
+        **Documentation**:
+            https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-folders-folder_id-contents-GET/
+
+        Args:
+            project_id (str): The unique identifier of a project.
+            folder_id (str): The unique identifier of a folder.
+
+        Returns:
+            dict: Dictionary with collection of items and folders within a folder.
+
+        Examples:
+            ```
+            THREE_LEGGED_TOKEN = os.environ["THREE_LEGGED_TOKEN"]
+            client = DataManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
+            content = client.get_content("some-project-id", "some-folder-id")
+            for data in content['data']:
+                print(data)
+            ```
+        """
+        headers = { "Content-Type": "application/vnd.api+json" }
+        params = {}
+        if filter_id:
+            params["filter[id]"] = filter_id
+        endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/folders/{folder_id}/contents"
+        return self._get_paginated(endpoint, scopes=READ_SCOPES, headers=headers, params=params)
+
+    def get_item(self, project_id: str, item_id: str, filter_id: str=None) -> dict:
+        """
+        Retrieves metadata for a specified item. Items represent word documents, fusion design files, drawings, spreadsheets, etc.
+
+        **Documentation**:
+            https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-items-item_id-GET/
+
+        Args:
+            project_id (str): ID of a project to get item metadata for.
+            item_id (str): ID of the item to get metadata for.
+
+        Returns:
+            dict: Dict of folders parsed from the response JSON.
+
+        Examples:
+            ```
+            THREE_LEGGED_TOKEN = os.environ["THREE_LEGGED_TOKEN"]
+            client = DataManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
+            item = client.get_item("some-project-id", "some-item-id")
+            print(item)
+            ```
+        """
+        headers = { "Content-Type": "application/vnd.api+json" }
+        params = {}
+        if filter_id:
+            params["filter[id]"] = filter_id
+        endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/items/{item_id}"
+        return self._get(endpoint, scopes=READ_SCOPES, headers=headers, params=params).json()
+    
+    def download_item(self, item: dict, location: str = '') -> dict:
+        """
+        Retrieves metadata for a specified item. Items represent word documents, fusion design files, drawings, spreadsheets, etc.
+
+        **Documentation**:
+            https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-items-item_id-GET/
+
+        Args:
+            item (dict): dictionary containing metadata for the item.
+            location (str): path to directory where file should be downloaded.
+
+        Returns:
+            dict: Dict of folders parsed from the response JSON.
+
+        """
+        
+        try:
+
+            download_link = item['included'][0]['relationships']['storage']['meta']['link']['href']
+
+        except Exception as exception:
+            print('item has no storage link "included.relationships.storage.meta.link.href".', {exception})
+
+        assert len(item['included']) <= 1, 'More than one "included" object. This is not supported by forge-sdk-python.'
+
+        filename = item['data']['attributes']['displayName']
+
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        #endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/items/{item_id}"
+        res = self._get(download_link, scopes=READ_SCOPES, headers=headers)
+
+        with open(path.join(location, filename), 'wb') as file:
+            file.write(res.content)
+    
+    def create_storage(self, project_id, filename, resource_id, target_type):
+
+        '''
+        Creates a storage location in the OSS where data can be uploaded to.
+
+        documentation:
+        https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-storage-POST/
+
+        Args:
+            project_id (str): ID of a project to get item metadata for.
+            filename (str): Displayable name of the resource.
+            resource_id (str): The id of the resource.
+
+        Returns:
+            dict: Dict of folders parsed from the response JSON.
+        '''
+        # The POST projects/:project_id/storage endpoint creates a storage location in the OSS.
+        # the object is like urn:adsk.objects:os.object:wip.dm.emea.2/47072f30-f04e-4a9f-939f-64114e16c050.docx
+        #logger.info(f'create_storage project_id: {project_id}, filename:{filename}, folder_id: {folder_id}')
+        #url = f'https://developer.api.autodesk.com/data/v1/projects/b.{project_id}/storage'
+        
+        #headers = {'Authorization': f'Bearer {token} ', 'Content-Type': 'application/json'} # Content-Type: application/vnd.api+json
+
+        body = { "jsonapi": { "version": "1.0" }, "data": {  "type": "objects",
+                        "attributes": {
+                        "name": filename
+                    },
+            "relationships": {
+                "target": {
+                "data": {
+                    "type": target_type,
+                    "id": resource_id # "urn:adsk.wipprod:fs.folder:co.mgS-lb-BThaTdHnhiN_mbA"
+                }
+                }
+            }
+        }}
+
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        endpoint = f"{DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/storage"
+        return self._post(endpoint, scopes=WRITE_SCOPES, headers=headers, json=body).json()
+
+
+    def new_file_version(self, project_id, filename, item_id, object_id, type):
+
+        '''
+        Creates new versions of a file (item), except for the first version of the item.
+
+        documentation:
+        https://forge.autodesk.com/en/docs/data/v2/reference/http/projects-project_id-versions-POST/
+
+        Args:
+            project_id (str): ID of a project to get item metadata for.
+            filename (str): Displayable name of the resource.
+            object_id (str): The id of the resource.
+            type (str): The id of the resource.
+
+        
+        '''
+
+        body = {
+            "jsonapi": {"version": "1.0"},
+            "data": {
+                "type": "versions",
+                "attributes": {
+                    "name": filename,
+                    "extension": {"type": type, "version": "1.0"}
+                },
+                "relationships": {
+                    "item": {"data": {"type": "items", "id": item_id}},
+                    "storage": {"data": {"type": "objects",
+                                         "id": object_id}}
+                }
+            }
+        }
+
+
+        headers = { "Content-Type": "application/vnd.api+json" }
+        
+        endpoint = f' {DATA_MANAGEMENT_DATA_URL}/projects/{project_id}/versions'
+        return self._post(endpoint, scopes=WRITE_SCOPES, headers=headers, json=body).json()

--- a/src/autodesk_forge_sdk/md.py
+++ b/src/autodesk_forge_sdk/md.py
@@ -3,6 +3,7 @@ Clients for working with the Forge Model Derivative service.
 """
 
 import base64
+from typing import List
 from .auth import BaseOAuthClient, Scope, TokenProviderInterface
 
 BASE_URL = "https://developer.api.autodesk.com/modelderivative/v2"
@@ -93,7 +94,7 @@ class ModelDerivativeClient(BaseOAuthClient):
         """
         return self._get("/designdata/formats", scopes=[]).json()
 
-    def submit_job(self, urn: str, output_formats: list[dict], **kwargs) -> dict:
+    def submit_job(self, urn: str, output_formats: List[dict], **kwargs) -> dict:
         """
         Translate a design from one format to another format.
 
@@ -102,7 +103,7 @@ class ModelDerivativeClient(BaseOAuthClient):
 
         Args:
             urn (str): Base64-encoded ID of the object to translate.
-            output_formats (list[dict]): List of objects representing all the requested outputs.
+            output_formats (List[dict]): List of objects representing all the requested outputs.
                 Each object should have at least `type` property set to "svf", "svf2", etc.
             output_region (str): Output region. Allowed values: "US", "EMEA".
             root_filename (str, optional): Starting filename if the converted file is a ZIP archive.


### PR DESCRIPTION
Replaced list with typing.List.

It seems the current code requires 3.9 to run.
Else hinting as "scopes: list[Scope]" will fail with a "TypeError: 'type' object is not subscriptable".