### PR TITLE
added two document management custom attributes endpoints

### DIFF
--- a/src/autodesk_forge_sdk/docm.py
+++ b/src/autodesk_forge_sdk/docm.py
@@ -169,3 +169,24 @@ class DocumentManagementClient(BaseOAuthClient):
 
         return self._post(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/versions/{version_id}/custom-attributes:batch-update",
         scopes=READ_SCOPES, headers=headers, json=attributes).json()
+    
+    def get_folder_permissions(self, project_id, folder_id) -> dict:
+        """
+        Retrieves information about the permissions assigned to users, roles and companies for a BIM 360 Document Management folder,
+        including details about the name and the status.
+
+        **Documentation**:
+        https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-projects-project_id-folders-folder_id-permissions-GET/
+
+        Args:
+            project_id (str, required): The ID of the project. This corresponds to project ID in the Data Management API. To convert a project ID in the Data Management API into a project ID in the BIM 360 API you need to remove the “b.” prefix.
+            folder_id (str, required): The ID (URN) of the folder.
+
+        Returns:
+            dict: a list of dictionaries containing data on the users with access and their permissions
+
+        """
+        headers = { "Content-Type": "application/json" }
+
+        return self._get(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/folders/{folder_id}/permissions",
+        scopes=READ_SCOPES, headers=headers).json()

--- a/src/autodesk_forge_sdk/docm.py
+++ b/src/autodesk_forge_sdk/docm.py
@@ -4,6 +4,7 @@ Clients for working with the Forge Document Management service.
 # from os import path
 # from enum import Enum
 from typing import Union
+from urllib import request, parse
 from .auth import BaseOAuthClient, Scope, TokenProviderInterface
 
 BASE_URL = "https://developer.api.autodesk.com"
@@ -103,6 +104,27 @@ class DocumentManagementClient(BaseOAuthClient):
         return self._get(f"/projects/{project_id}/naming-standards/{naming_standard_ids[0]}",
             scopes=READ_SCOPES, headers=headers).json()
     
+    def get_custom_attribute_definitions_for_docs(self, project_id: str, urns: list) -> dict:
+        """
+        Retrieves a list of custom attribute values for multiple Document Management documents..
+
+        **Documentation**:
+        https://forge.autodesk.com/en/docs/bim360/v1/reference/http/document-management-versionsbatch-get-POST/
+
+        Args:
+            project_id (str, required): project ID
+            urns (list, required): A list of version IDs or item IDs. If you use item IDs it retrieves the values for the latest (tip) versions. You can specify up to 50 documents.
+
+        Returns:
+            dict: dictionary containing custom attribute.
+
+        """
+        headers = { "Content-Type": "application/vnd.api+json" }
+        data = {"urns": urns}
+
+        return self._post(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/versions:batch-get",
+        scopes=READ_SCOPES, headers=headers, json=data).json()
+    
     def get_custom_attribute_definitions(self, project_id, folder_id) -> dict:
         """
         Retrieves a complete list of custom attribute definitions for all the documents
@@ -119,10 +141,31 @@ class DocumentManagementClient(BaseOAuthClient):
         Returns:
             dict: dictoionary of naming standard from the JSON response.
 
-
-        
         """
         headers = { "Content-Type": "application/vnd.api+json" }
 
         return self._get(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/folders/{folder_id}/custom-attribute-definitions",
         scopes=READ_SCOPES, headers=headers).json()
+    
+    def batch_update_custom_attribute_definitions(self, project_id, version_id, attributes: dict) -> dict:
+        """
+        Assigns values to custom attributes for multiple documents. This endpoint also clears custom attribute values.
+
+        **Documentation**:
+        https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-custom-attributesbatch-update-POST
+
+        Args:
+            project_id (str): project ID
+            version_id (str): The URL-encoded ID (URN) of the version.
+            new_values (dict): new values for custom attributes. ex: [{"id": 1001,"value": "checked"},{"id": 1002,"value": "2020-03-31T16:00:00.000Z"}]
+
+        Returns:
+            dict: dictionary of assigned values for the custom attributes .
+
+        """
+        version_id = parse.quote(version_id)
+
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        return self._post(f"{DOCUMENT_MANAGEMENT_URL}/projects/{project_id}/versions/{version_id}/custom-attributes:batch-update",
+        scopes=READ_SCOPES, headers=headers, json=attributes).json()


### PR DESCRIPTION
added two document management endpoints for custom attributes.

Retrieves a list of custom attribute values for multiple Document Management documents.
https://forge.autodesk.com/en/docs/bim360/v1/reference/http/document-management-versionsbatch-get-POST/

Assigns values to custom attributes for multiple documents. This endpoint also clears custom attribute values.
https://forge.autodesk.com/en/docs/acc/v1/reference/http/document-management-custom-attributesbatch-update-POST

