### PR TITLE
added new account management endpoints

### DIFF
--- a/src/autodesk_forge_sdk/__init__.py
+++ b/src/autodesk_forge_sdk/__init__.py
@@ -4,8 +4,8 @@ Clients for communicating with different Autodesk Forge services.
 
 from .auth import AuthenticationClient, Scope, get_authorization_url
 from .auth import TokenProviderInterface, SimpleTokenProvider, OAuthTokenProvider
-from .datam import OSSClient, DataManagementClient
+from .datam import OSSClient, DataManagementClient, DataRetention
 from .md import ModelDerivativeClient, urnify
 from .docm import DocumentManagementClient
-from .accm import AccountManagementClient
+from .accm import AccountManagementClient, AccountManagementClient_BIM360
 from .webhooks import WebhooksClient

--- a/src/autodesk_forge_sdk/accm.py
+++ b/src/autodesk_forge_sdk/accm.py
@@ -268,13 +268,9 @@ class AccountManagementClient_BIM360(BaseOAuthClient):
             ```
         """
 
-        #url = f"/bim360/admin/v1/projects/{project_id}/users"
-
-        url = f"https://developer.api.autodesk.com/bim360/admin/v1/projects/{project_id}/users"
+        url = f"/projects/{project_id}/users"
 
         headers = { "Content-Type": "application/vnd.api+json" }
 
         return self._get_paginated(url,
             scopes=READ_SCOPES, headers=headers)
-
-    

--- a/src/autodesk_forge_sdk/accm.py
+++ b/src/autodesk_forge_sdk/accm.py
@@ -8,7 +8,9 @@ from .auth import BaseOAuthClient, Scope, TokenProviderInterface
 
 BASE_URL = "https://developer.api.autodesk.com"
 ACCOUNT_MANAGEMENT_URL = f"{BASE_URL}/hq/v1"
-READ_SCOPES = [Scope.BUCKET_READ, Scope.DATA_READ]
+ACCOUNT_MANAGEMENT_URL_V2 = f"{BASE_URL}/hq/v2"
+ACCOUNT_MANAGEMENT_URL_BIM360 = f"{BASE_URL}/bim360/admin/v1"
+READ_SCOPES = [Scope.BUCKET_READ, Scope.DATA_READ, Scope.ACCOUNT_READ]
 WRITE_SCOPES = [Scope.BUCKET_CREATE, Scope.DATA_CREATE, Scope.DATA_WRITE]
 DELETE_SCOPES = [Scope.BUCKET_DELETE]
 
@@ -46,14 +48,24 @@ class AccountManagementClient(BaseOAuthClient):
         BaseOAuthClient.__init__(self, token_provider, ACCOUNT_MANAGEMENT_URL)
 
     def _get_paginated(self, url: str, **kwargs) -> List:
+        limit = 100 # lowest max limit for all endpoints seems to be 100.
         items = []
+        offset = 0
+
         while url:
-            json = self._get(url, **kwargs).json()
-            items = items + json["items"]
-            if "next" in json:
-                url = json["next"]
+
+            url_pagination = f"{url}?offset={offset}&limit={limit}"
+            json = self._get(url_pagination, **kwargs).json()
+
+            items += json
+
+            # if number of returned objects is equal to the limit, there might be more objects to get.
+            if len(json) == limit:
+                offset += limit
+
             else:
                 url = None
+
         return items
 
     
@@ -82,7 +94,7 @@ class AccountManagementClient(BaseOAuthClient):
         if user_id:
 
             url = f"/accounts/{account_id}/users/{user_id}"
-        
+
         else:
 
             url = f"/accounts/{account_id}/users"
@@ -120,9 +132,149 @@ class AccountManagementClient(BaseOAuthClient):
 
         if kwargs: # TODO: test if this works
             params.update(kwargs)
-        
+
         headers = { "Content-Type": "application/vnd.api+json" }
 
         return self._get(url,
             scopes=READ_SCOPES, headers=headers,
             params=params).json()
+    
+    def get_companies(self, account_id: str) -> List:
+        """
+        Query all the partner companies in a specific BIM 360 or ACC account.
+
+        **Documentation**: https://forge.autodesk.com/en/docs/acc/v1/reference/http/companies-GET/
+
+        Args:
+            account_id (str): The account ID of the user. This corresponds to hub ID in the Data Management API. To convert a hub ID into an account ID you need to remove the “b.” prefix. For example, a hub ID of b.c8b0c73d-3ae9 translates to an account ID of c8b0c73d-3ae9.
+
+        Returns:
+            List(Dict): List of dictionary parsed from the response JSON.
+
+        Examples:
+            ```
+            from autodesk_forge_sdk import DataManagementClient
+
+            datam_client = DataManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+            companies = accm_client.get_companies('account_id')
+            ```
+        """
+        url = f'/accounts/{account_id}/companies'
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        return self._get_paginated(url,
+            scopes=READ_SCOPES, headers=headers)
+
+    def get_industry_roles(self, account_id: str, project_id: str) -> List:
+        """
+        Retrieves the industry roles for the project. For example, contractor and architect.
+
+        **Documentation**: https://forge.autodesk.com/en/docs/bim360/v1/reference/http/projects-project_id-industry_roles-GET/
+
+        Args:
+            account_id (str): The account ID of the user. This corresponds to hub ID in the Data Management API. To convert a hub ID into an account ID you need to remove the “b.” prefix. For example, a hub ID of b.c8b0c73d-3ae9 translates to an account ID of c8b0c73d-3ae9.
+            project_id (str): The project ID. This corresponds to project ID in the Data Management API. To convert a project ID in the Data Management API into a project ID in the BIM 360 API you need to remove the “b.” prefix. For example, a project ID of b.a4be0c34a-4ab7 translates to a project ID of a4be0c34a-4ab7.
+
+        Returns:
+            List(Dict): List of dictionary parsed from the response JSON.
+
+        Examples:
+            ```
+            from autodesk_forge_sdk import AccountManagementClient
+
+            accm_client = AccountManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+            industry_roles = self.accm_client.get_industry_roles('account_id', 'project_id')
+            ```
+        """
+        url = f'{ACCOUNT_MANAGEMENT_URL_V2}/accounts/{account_id}/projects/{project_id}/industry_roles'
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        return self._get(url,
+            scopes=READ_SCOPES, headers=headers).json()
+
+class AccountManagementClient_BIM360(BaseOAuthClient):
+    """
+    Forge Account Management client.
+
+    **Documentation**: https://forge.autodesk.com/en/docs/acc/v1/overview/introduction/
+    """
+
+    def __init__(
+        self, token_provider: TokenProviderInterface):
+        """
+        Create new instance of the client.
+
+        Args:
+            token_provider (autodesk_forge_sdk.auth.TokenProviderInterface):
+                Provider that will be used to generate access tokens for API calls.
+
+                Use `autodesk_forge_sdk.auth.OAuthTokenProvider` if you have your app's client ID
+                and client secret available, `autodesk_forge_sdk.auth.SimpleTokenProvider`
+                if you would like to use an existing access token instead, or even your own
+                implementation of the `autodesk_forge_sdk.auth.TokenProviderInterface` interface.
+
+                Note that many APIs in the Forge Data Management service require
+                a three-legged OAuth token.
+            base_url (str, optional): Base URL for API calls.
+
+        Examples:
+            ```
+            THREE_LEGGED_TOKEN = os.environ["THREE_LEGGED_TOKEN"]
+            client = DataManagementClient(SimpleTokenProvider(THREE_LEGGED_TOKEN))
+            ```
+        """
+        BaseOAuthClient.__init__(self, token_provider, ACCOUNT_MANAGEMENT_URL_BIM360)
+
+    def _get_paginated(self, url: str, **kwargs) -> List:
+        limit = 100 # lowest max limit for all endpoints seems to be 100.
+        items = []
+        offset = 0
+
+        while url:
+
+            url_pagination = f"{url}?offset={offset}&limit={limit}"
+            json = self._get(url_pagination, **kwargs).json()
+   
+            total_results = json["pagination"]["totalResults"]
+
+            items += json["results"]
+
+            if (total_results > limit) and (total_results - offset > 0):
+                offset += limit
+            
+            else:
+                url = None
+
+        return items
+
+    def get_project_users(self, project_id: str) -> Dict:
+        """
+        Retrieves information about all the users in a project.
+
+        **Documentation**: https://forge.autodesk.com/en/docs/bim360/v1/reference/http/admin-v1-projects-projectId-users-GET/
+
+        Args:
+            project_id (str): The project ID. This corresponds to project ID in the Data Management API. To convert a project ID in the Data Management API into a project ID in the BIM 360 API you need to remove the “b.” prefix.
+
+        Returns:
+            List(Dict): Dictionary parsed from the response JSON.
+
+        Examples:
+            ```
+            from autodesk_forge_sdk import AccountManagementClient
+            
+            accm_client = AccountManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+            users = accm_client.get_project_users('project_id')
+            ```
+        """
+
+        #url = f"/bim360/admin/v1/projects/{project_id}/users"
+
+        url = f"https://developer.api.autodesk.com/bim360/admin/v1/projects/{project_id}/users"
+
+        headers = { "Content-Type": "application/vnd.api+json" }
+
+        return self._get_paginated(url,
+            scopes=READ_SCOPES, headers=headers)
+
+    

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,7 +7,8 @@ from autodesk_forge_sdk import OAuthTokenProvider, SimpleTokenProvider
 from autodesk_forge_sdk import OSSClient, DataManagementClient
 from autodesk_forge_sdk import ModelDerivativeClient, urnify
 from autodesk_forge_sdk import WebhooksClient
-
+from autodesk_forge_sdk import AccountManagementClient, AccountManagementClient_BIM360
+from autodesk_forge_sdk import DocumentManagementClient
 FORGE_CLIENT_ID = os.environ["FORGE_CLIENT_ID"]
 FORGE_CLIENT_SECRET = os.environ["FORGE_CLIENT_SECRET"]
 FORGE_BUCKET = os.environ["FORGE_BUCKET"]

--- a/tests/test_accm.py
+++ b/tests/test_accm.py
@@ -1,0 +1,106 @@
+import unittest
+
+from .context import (FORGE_CLIENT_ID, FORGE_CLIENT_SECRET,
+                      AccountManagementClient, AccountManagementClient_BIM360,
+                      DataManagementClient, OAuthTokenProvider)
+
+
+class WebhooksTestSuite(unittest.TestCase):
+    """Forge Data Management OSS client test cases."""
+
+    def setUp(self):
+        self.accm_client = AccountManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+        self.accm_client_bim360 = AccountManagementClient_BIM360(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+        self.datam_client = DataManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+
+    def test_get_project_users(self):
+        '''
+        test get_project_users. returns all users in a project.
+        '''
+
+        hubs = self.datam_client.get_all_hubs()
+
+        self.assertIsNotNone(hubs)
+
+        assert len(hubs) > 0, "No hubs found"
+
+        projects = self.datam_client.get_projects(hubs[0]['id'])
+        self.assertIsNotNone(projects)
+
+        assert 'data' in projects
+        self.assertIsInstance(projects['data'], list)
+        project = projects['data'][0]
+
+        assert len(project) > 0, "no data in project"
+        assert 'id' in project, "No project ID in project object"
+        
+        project_id = project['id']
+        users = self.accm_client_bim360.get_project_users(project_id)
+
+        assert isinstance(users, list)
+
+        if len(users) > 0:
+
+            user = users[0]
+
+            assert 'services' in user
+
+            assert isinstance(user['services'], list)
+
+    def test_get_companies(self):
+        '''
+        test get_project_users. returns all users in a project.
+        '''
+
+        hubs = self.datam_client.get_all_hubs()
+        self.assertIsNotNone(hubs)
+        assert len(hubs) > 0, "No hubs found"
+
+        account_id = hubs[0]['id'].split('b.')[1]
+        companies = self.accm_client.get_companies(account_id)
+
+        self.assertIsNotNone(hubs)
+
+
+
+        assert len(hubs) > 0, "No hubs found"
+
+        projects = self.datam_client.get_projects(hubs[0]['id'])
+        self.assertIsNotNone(projects)
+    
+    def test_get_industry_roles(self):
+        '''
+        test get_project_users. returns all industry_roles in a project.
+        '''
+
+        hubs = self.datam_client.get_all_hubs()
+        self.assertIsNotNone(hubs)
+        assert len(hubs) > 0, "No hubs found"
+
+        projects = self.datam_client.get_projects(hubs[0]['id'])
+        self.assertIsNotNone(projects)
+
+        assert 'data' in projects
+
+        self.assertIsInstance(projects['data'], list)
+
+        project = projects['data'][0]
+
+        assert len(project) > 0, "no data in project"
+        assert 'id' in project, "No project ID in project object"
+        
+        project_id = project['id'].split('b.')[1]
+        account_id = hubs[0]['id'].split('b.')[1]
+
+        industry_roles = self.accm_client.get_industry_roles(account_id, project_id)
+
+        assert isinstance(industry_roles, list)
+
+        if len(industry_roles) > 0:
+
+            industry_role = industry_roles[0]
+
+            assert 'member_group_id' in industry_role
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dm.py
+++ b/tests/test_dm.py
@@ -1,5 +1,5 @@
 import unittest
-from .context import OSSClient, DataManagementClient, OAuthTokenProvider, FORGE_CLIENT_ID, FORGE_CLIENT_SECRET, FORGE_BUCKET
+from .context import OSSClient, DataManagementClient, DocumentManagementClient, OAuthTokenProvider, FORGE_CLIENT_ID, FORGE_CLIENT_SECRET, FORGE_BUCKET
 
 class OSSClientTestSuite(unittest.TestCase):
     """Forge Data Management OSS client test cases."""
@@ -49,11 +49,42 @@ class DataManagementTestSuite(unittest.TestCase):
     """Forge Data Management client test cases."""
 
     def setUp(self):
-        self.client = DataManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+        self.data_client = DataManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
+        self.docm_client = DocumentManagementClient(OAuthTokenProvider(FORGE_CLIENT_ID, FORGE_CLIENT_SECRET))
 
     def test_get_all_hubs(self):
-        hubs = self.client.get_all_hubs()
+        hubs = self.data_client.get_all_hubs()
         self.assertIsNotNone(hubs)
+
+    def test_get_projects(self):
+
+        hubs = self.data_client.get_all_hubs()
+        self.assertIsNotNone(hubs)
+
+        projects = self.data_client.get_projects(hubs[0]['id'])
+        self.assertIsNotNone(projects)
+
+
+    def test_get_folder_permissions(self):
+
+        hubs = self.data_client.get_all_hubs()
+        self.assertIsNotNone(hubs)
+
+        projects = self.data_client.get_projects(hubs[0]['id'])
+        self.assertIsNotNone(projects)
+
+        project_id = projects['data'][0]['id'].split('b.')[1]
+
+        root_folder_id = projects["data"][0]['relationships']["rootFolder"]["data"]["id"]
+
+        projects = self.docm_client.get_folder_permissions(project_id, root_folder_id)
+        self.assertIsNotNone(projects)
+
+        if len(projects) > 0:
+
+            project = projects[0]
+            assert 'actions' in project
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added new endpoints to data management and a test file _tests/test_accm.py_.

I would love a second opinion on the pull request:

**Tests**
 For instance the test _[test_get_industry_roles()](https://github.com/petrbroz/forge-sdk-python/pull/17/files#diff-217b3424a9710727996801197e84fce23b26456f97966a04718323a1c5e2b581R71)_ uses methods from the Data Management test to get account ID and project ID, and code duplicated from other tests. Not sure how to make this more clean.

**Organizing endpoints and versions**
To get companies and industry roles you have to use two different version of the **hq** endpoint since industry roles only exists as `/hq/2` and companies only as version `/hq/1`. For this pull request, both endpoints are define in the same file, as methods in the same class.

Getting users for at project is depended on the _/bim360/admin/v1_ endpoint. I placed it in the same file _accm.py_ in a new class called `AccountManagementClient_BIM360`. Should it be placed in its own file? Fx _bim360_accm.py_.


GET companies uses `/hq/v1`
https://forge.autodesk.com/en/docs/acc/v1/reference/http/companies-GET/

GET industry roles uses `/hq/v2`
https://forge.autodesk.com/en/docs/bim360/v1/reference/http/projects-project_id-industry_roles-GET/

GET project roles uses `/bim360/admin/v1`
https://forge.autodesk.com/en/docs/bim360/v1/reference/http/admin-v1-projects-projectId-users-GET/